### PR TITLE
lwarp wants unicode-math loaded after

### DIFF
--- a/datasheet.sty
+++ b/datasheet.sty
@@ -7,8 +7,8 @@
                 [2020/09/02 Datasheet Package]
 
 %% Load additional packages and commands.
-\RequirePackage{unicode-math}
 \RequirePackage{lwarp}
+\RequirePackage{unicode-math}
 \RequirePackage{verbatim}
 \RequirePackage{caption}
 \RequirePackage{listings}
@@ -21,7 +21,9 @@
   \typeout{datasheet:AfterEndPreamble}
   \setmainfont{Stix Two Text}
   \setsansfont{TeX Gyre Heros}
-  \setmathfont{Stix Two Math}
+  % Setting Math font causes
+  %   Latexmk: Maximum runs of lualatex reached without getting stable files
+  %\setmathfont{Stix Two Math}
   \typeout{layout}
   \settypeoutlayoutunit{in}
   \setlrmarginsandblock{0.5in}{*}{*}


### PR DESCRIPTION
After Fedora 33 update, lwarp complained:

  Package lwarp Error: Package amsmath,
  (lwarp)                or one which uses amsmath,
  (lwarp)                must be loaded after Lwarp.
  (lwarp)                Enter 'H' for possible solutions.

After correcting that, lwarpmk complained:

  Latexmk: Maximum runs of lualatex reached without getting stable files

Commenting out

  \setmathfont{Stix Two Math}

stopped the complaint.

May look into this further, but at least the package works again.