### PR TITLE
Move margin setting and font code

### DIFF
--- a/datasheet.mk
+++ b/datasheet.mk
@@ -33,4 +33,4 @@ release: html
 	cp -a $(PRJ).html $(PRJ)-images lwarp.css $(REL)
 
 clean:
-	-rm -rf *.{pdf,aux,log,dvi,css,lwarpmkconf,cut,txt,fdb_latexmk,fls,svg} lwarp* *html* *-images
+	-rm -rf *.{pdf,aux,log,dvi,css,lwarpmkconf,cut,txt,fdb_latexmk,fls,svg} lwarp* *html* *-images $(PRJ).out

--- a/datasheet.sty
+++ b/datasheet.sty
@@ -16,20 +16,18 @@
 \RequirePackage{etoolbox}
 \tracinglwarp
 
+\setmainfont{Stix Two Text}
+\setsansfont{TeX Gyre Heros}
+\setmathfont{Stix Two Math}
+\typeout{layout}
+\settypeoutlayoutunit{in}
+\setlrmarginsandblock{0.5in}{*}{*}
+\setulmarginsandblock{0.5in}{0.75in}{*}
+\checkandfixthelayout
+
 %% Additional TeX/LaTeX code...
 \AfterEndPreamble{
   \typeout{datasheet:AfterEndPreamble}
-  \setmainfont{Stix Two Text}
-  \setsansfont{TeX Gyre Heros}
-  \setmathfont{Stix Two Math}
-  \typeout{layout}
-  \settypeoutlayoutunit{in}
-  \setlrmarginsandblock{0.5in}{*}{*}
-  \setulmarginsandblock{0.5in}{0.75in}{*}
-  \checkandfixthelayout
-  % force paragraph width to margins
-  \hsize\textwidth
-  \typeout{hsize \the\hsize}
 
   % from http://tug.org/pracjourn/2008-2/madsen/madsen.pdf
   \warpprintonly{


### PR DESCRIPTION
Margin setting and font code is moved out of lwarp
AfterEndPreamble and into body of style. This fixes the
adjustment of abstract and quotation environment margins.

hsize hack is not needed so remove.

Add $PRJ.out to clean target

fixes #8