### PR TITLE
Poll for temp file removal

### DIFF
--- a/datasheet.mk
+++ b/datasheet.mk
@@ -29,7 +29,21 @@ $(PRJ).pdf: $(PRJ).tex $(DEP)
 	latexmk $(LMK) $<
 	lwarpmk $(LWK) print
 
+#
+# lwarpmk does background image processing with no obvious way to wait for
+# completion, which is probably why it says
+#
+#   "Wait a moment for the images to complete"
+#
+# We will just wait until the temp images go away
+#
 release: html
+	for file in $(PRJ)-images/lateximagetemp-*; do \
+	    while [ -f $$file ]; do \
+	        echo "wait for $$file deletion"; \
+	        sleep 1; \
+	    done; \
+	done
 	cp -a $(PRJ).html $(PRJ)-images lwarp.css $(REL)
 
 clean:


### PR DESCRIPTION
lwarpmk does image processing in the background which can cause a race condition in the release target.

release now waits until the (remaining) temp files are gone before doing the copy.